### PR TITLE
added encoder to whisper function in LLMWhisperClient

### DIFF
--- a/src/unstract/llmwhisperer/client.py
+++ b/src/unstract/llmwhisperer/client.py
@@ -191,7 +191,7 @@ class LLMWhispererClient:
             ocr_provider (str, optional): The OCR provider. Can be "advanced" or "basic". Defaults to "advanced".
             line_splitter_tolerance (float, optional): The line splitter tolerance. Defaults to 0.4.
             horizontal_stretch_factor (float, optional): The horizontal stretch factor. Defaults to 1.0.
-            encoder (str): The character encoding to use for processing the text. Defaults to "ISO-8859-1".
+            encoding (str): The character encoding to use for processing the text. Defaults to "utf-8".
 
         Returns:
             dict: The response from the API as a dictionary.
@@ -296,6 +296,7 @@ class LLMWhispererClient:
 
         Args:
             whisper_hash (str): The hash of the whisper (returned by whisper method)
+            encoding (str): The character encoding to use for processing the text. Defaults to "utf-8".
 
         Returns:
             dict: A dictionary containing the status of the whisper operation. The keys in the

--- a/src/unstract/llmwhisperer/client.py
+++ b/src/unstract/llmwhisperer/client.py
@@ -169,6 +169,7 @@ class LLMWhispererClient:
         ocr_provider: str = "advanced",
         line_splitter_tolerance: float = 0.4,
         horizontal_stretch_factor: float = 1.0,
+        encoder = "ISO-8859-1"
     ) -> dict:
         """
         Sends a request to the LLMWhisperer API to process a document.
@@ -190,6 +191,7 @@ class LLMWhispererClient:
             ocr_provider (str, optional): The OCR provider. Can be "advanced" or "basic". Defaults to "advanced".
             line_splitter_tolerance (float, optional): The line splitter tolerance. Defaults to 0.4.
             horizontal_stretch_factor (float, optional): The horizontal stretch factor. Defaults to 1.0.
+            encoder (str): The character encoding to use for processing the text. Defaults to "ISO-8859-1".
 
         Returns:
             dict: The response from the API as a dictionary.
@@ -268,6 +270,7 @@ class LLMWhispererClient:
         prepared = req.prepare()
         s = requests.Session()
         response = s.send(prepared, timeout=self.api_timeout, stream=should_stream)
+        response.encoding = encoder
         if response.status_code != 200 and response.status_code != 202:
             message = json.loads(response.text)
             message["status_code"] = response.status_code

--- a/src/unstract/llmwhisperer/client.py
+++ b/src/unstract/llmwhisperer/client.py
@@ -169,7 +169,7 @@ class LLMWhispererClient:
         ocr_provider: str = "advanced",
         line_splitter_tolerance: float = 0.4,
         horizontal_stretch_factor: float = 1.0,
-        encoder = "ISO-8859-1"
+        encoding: str = "utf-8"
     ) -> dict:
         """
         Sends a request to the LLMWhisperer API to process a document.
@@ -270,7 +270,7 @@ class LLMWhispererClient:
         prepared = req.prepare()
         s = requests.Session()
         response = s.send(prepared, timeout=self.api_timeout, stream=should_stream)
-        response.encoding = encoder
+        response.encoding = encoding
         if response.status_code != 200 and response.status_code != 202:
             message = json.loads(response.text)
             message["status_code"] = response.status_code
@@ -285,7 +285,7 @@ class LLMWhispererClient:
             "whisper_hash": response.headers["whisper-hash"],
         }
 
-    def whisper_status(self, whisper_hash: str) -> dict:
+    def whisper_status(self, whisper_hash: str, encoding: str = "utf-8") -> dict:
         """Retrieves the status of the whisper operation from the LLMWhisperer
         API.
 
@@ -313,6 +313,7 @@ class LLMWhispererClient:
         prepared = req.prepare()
         s = requests.Session()
         response = s.send(prepared, timeout=self.api_timeout)
+        response.encoding = encoding
         if response.status_code != 200:
             err = json.loads(response.text)
             err["status_code"] = response.status_code

--- a/src/unstract/llmwhisperer/client.py
+++ b/src/unstract/llmwhisperer/client.py
@@ -285,7 +285,7 @@ class LLMWhispererClient:
             "whisper_hash": response.headers["whisper-hash"],
         }
 
-    def whisper_status(self, whisper_hash: str, encoding: str = "utf-8") -> dict:
+    def whisper_status(self, whisper_hash: str) -> dict:
         """Retrieves the status of the whisper operation from the LLMWhisperer
         API.
 
@@ -296,7 +296,6 @@ class LLMWhispererClient:
 
         Args:
             whisper_hash (str): The hash of the whisper (returned by whisper method)
-            encoding (str): The character encoding to use for processing the text. Defaults to "utf-8".
 
         Returns:
             dict: A dictionary containing the status of the whisper operation. The keys in the
@@ -314,7 +313,6 @@ class LLMWhispererClient:
         prepared = req.prepare()
         s = requests.Session()
         response = s.send(prepared, timeout=self.api_timeout)
-        response.encoding = encoding
         if response.status_code != 200:
             err = json.loads(response.text)
             err["status_code"] = response.status_code
@@ -323,7 +321,7 @@ class LLMWhispererClient:
         message["status_code"] = response.status_code
         return message
 
-    def whisper_retrieve(self, whisper_hash: str) -> dict:
+    def whisper_retrieve(self, whisper_hash: str, encoding: str = "utf-8") -> dict:
         """Retrieves the result of the whisper operation from the LLMWhisperer
         API.
 
@@ -334,6 +332,7 @@ class LLMWhispererClient:
 
         Args:
             whisper_hash (str): The hash of the whisper operation.
+            encoding (str): The character encoding to use for processing the text. Defaults to "utf-8".
 
         Returns:
             dict: A dictionary containing the status code and the extracted text from the whisper operation.
@@ -350,6 +349,7 @@ class LLMWhispererClient:
         prepared = req.prepare()
         s = requests.Session()
         response = s.send(prepared, timeout=self.api_timeout)
+        response.encoding = encoding
         if response.status_code != 200:
             err = json.loads(response.text)
             err["status_code"] = response.status_code


### PR DESCRIPTION
When processing documents in Arabic, the expected Arabic text was not returned correctly.
I added an encoder argument to the whisper function in LLMWhisperClient. The issue was resolved by encoding the response in UTF-8, which correctly handled the Arabic text. The encoder is set to default to ISO-8859-1, but can now be adjusted as needed.