### PR TITLE
LW-406 [FIX] send page_separator under both spellings

### DIFF
--- a/src/unstract/llmwhisperer/client_v2.py
+++ b/src/unstract/llmwhisperer/client_v2.py
@@ -517,7 +517,9 @@ class LLMWhispererClientV2:
         params = {
             "mode": mode,
             "output_mode": output_mode,
+            # Both spellings are sent: services older than v2.64.2 read only the misspelled one
             "page_separator": page_separator,
+            "page_seperator": page_separator,
             "pages_to_extract": pages_to_extract,
             "median_filter_size": median_filter_size,
             "gaussian_blur_radius": gaussian_blur_radius,

--- a/tests/unit/client_v2_test.py
+++ b/tests/unit/client_v2_test.py
@@ -209,9 +209,19 @@ def test_whisper_sends_corrected_param_names(mocker: MockerFixture, client_v2: L
     assert query["page_separator"] == ["---"]
     assert query["line_splitter_strategy"] == ["mid-priority"]
     assert query["file_name"] == ["invoice.pdf"]
-    assert "page_seperator" not in query
     assert "line_spitter_strategy" not in query
     assert "filename" not in query
+
+
+@pytest.mark.parametrize(("kwargs", "expected"), [({}, "<<<"), ({"page_separator": "---"}, "---")])
+def test_whisper_sends_page_separator_under_both_spellings(
+    mocker: MockerFixture, client_v2: LLMWhispererClientV2, kwargs: dict[str, str], expected: str
+) -> None:
+    """Older services read only the misspelled key, so both carry the value."""
+    query = _whisper_query(mocker, client_v2, **kwargs)
+
+    assert query["page_separator"] == [expected]
+    assert query["page_seperator"] == [expected]
 
 
 def test_whisper_defaults_when_no_param_passed(mocker: MockerFixture, client_v2: LLMWhispererClientV2) -> None:
@@ -224,11 +234,12 @@ def test_whisper_defaults_when_no_param_passed(mocker: MockerFixture, client_v2:
 
 
 def test_whisper_deprecated_page_seperator_is_forwarded(mocker: MockerFixture, client_v2: LLMWhispererClientV2) -> None:
-    """page_seperator still applies, under the corrected name."""
+    """page_seperator still applies, under both spellings on the wire."""
     with pytest.warns(DeprecationWarning, match="page_separator"):
         query = _whisper_query(mocker, client_v2, page_seperator="---")
 
     assert query["page_separator"] == ["---"]
+    assert query["page_seperator"] == ["---"]
 
 
 def test_whisper_deprecated_filename_is_forwarded(mocker: MockerFixture, client_v2: LLMWhispererClientV2) -> None:


### PR DESCRIPTION
## What

`whisper()` now sends the page separator value under **both** `page_separator` and `page_seperator`. One line in the `params` dict, plus tests.

The Python signature is unchanged — this is a wire-level fix only.

## Why

2.8.0 renamed the wire param from `page_seperator` to `page_separator`. The service only learned to read the corrected name in v2.64.2 (Zipstack/unstract-llm-whisperer#721). Against any older service, 2.8.0 drops the key entirely and the caller's page separator silently reverts to `<<<` — HTTP 200, no error, no warning.

That constraint is real for self-hosted and on-prem installs, which pick their own service version and supply their own `base_url`. Nothing in the shipped artifact records the requirement: it lives only in the #34 PR body, which is invisible to anyone running `pip install -U llmwhisperer-client`.

Note the asymmetry with the other two params 2.8.0 renamed. For `line_splitter_strategy` and `file_name` the **client** was the one misspelling, so the corrected names are what the service has always read and 2.8.0 is a strict improvement at any service version. For `page_separator` the **service** carried the typo, so the corrected name is the one that only recent builds understand. It is the only param where the rename can regress.

## How

Emitting both keys makes the client version-agnostic and removes the version constraint rather than documenting it:

- A service on v2.64.2+ reads `page_separator` and ignores the extra key.
- An older service reads `page_seperator` and ignores the one it does not know.

Flask drops unrecognised query params, so neither side errors on the key it does not read. The old key can come out at the next major, alongside the deprecated kwargs.

## Notes on Testing

`33 passed`, offline, no network.

- New parametrized test asserts both keys carry the same value, on the default path and with an explicit `page_separator=`.
- `test_whisper_deprecated_page_seperator_is_forwarded` extended to assert both keys.
- `test_whisper_sends_corrected_param_names` dropped its `assert "page_seperator" not in query`, which this change deliberately invalidates. The `line_spitter_strategy` and `filename` absence assertions are untouched — those keys are still correctly gone.

## Release

Patch bump. `__version__` is not touched here — the release workflow owns it via `workflow_dispatch`.

## Related

- Zipstack/llm-whisperer-python-client#34 — introduced the rename this softens
- Zipstack/unstract-llm-whisperer#721 — service-side `page_separator` support, released in v2.64.2
- Zipstack/unstract#2236 — the Unstract adapter picking up these params

## Still open from the #34 review, not addressed here

`file_name` is sent as an empty string on every default call, and the service's `request.args.get("file_name", "sample.pdf")` returns `""` for a present-but-empty key, so `document_name` lands blank in usage records for every caller who never set it. Worth folding into the same patch release if you want it — say the word and I will add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVoa8BMCNnhdkATd7A9U4J
